### PR TITLE
Add simple dh_maemo_icon helper.

### DIFF
--- a/debian/dh/dh_maemo_icon
+++ b/debian/dh/dh_maemo_icon
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Insert debian/maemo-icon.png into ${maemo:icon26} substition variable
+# for all binary packages for use in debian/control file.
+
+# Locate all package names
+# FIXME must be better way to do this?  Should handle -p for specific
+# package names.
+pkgs="$(awk '/^Package:/ {print $2}' debian/control)"
+
+icon=debian/maemo-icon.png
+if [ ! -e "$icon" ] ; then
+    echo "error: no icon file $icon available"
+    exit 1
+fi
+
+for pkg in $pkgs; do
+    substvars="debian/$pkg.substvars"
+    if grep -q ^maemo:icon26= "$substvars"; then
+	# Remove old entry if one exist already
+	grep -v ^maemo:icon26= "$substvars" \
+	     > $substvars.new && \
+	    mv $substvars.new "$substvars"
+    fi
+    echo maemo:icon26=\${Newline}$(base64 $icon | awk 1 ORS='${Newline}') \
+	 >> "$substvars"
+done

--- a/debian/rules
+++ b/debian/rules
@@ -23,7 +23,7 @@ install:
 	#done
 	cp -a debian/session/* debian/maemo-system-services/etc/X11
 	cp -a debian/dbus/* debian/maemo-system-services/etc/dbus-1
-	cp -a debian/dh/dh_install* debian/maemo-system-services-dev/usr/bin
+	cp -a debian/dh/dh_* debian/maemo-system-services-dev/usr/bin
 	cp -a debian/dh/postinst-* debian/maemo-system-services-dev/usr/share/debhelper/autoscripts/
 
 binary: binary-indep binary-arch


### PR DESCRIPTION
This will convert a debian/maemo-icon.png image into a
${maemo:icon26} substition variable usable in d/control.
This allow the icon to be maintained as a PNG in the
source repository.